### PR TITLE
new feature: keep only some properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ geojson-shave roads.geojson -d 3
 ```
 
 You can also specify if you only want certain Geometry object types in the file to be processed:
+
 ```
 $ geojson-shave roads.geojson -g LineString Polygon
 ```
@@ -63,7 +64,14 @@ And to reduce the file size even further you can nullify the property value of F
 $ geojson-shave roads.geojson -p
 ```
 
+Or select a positive list of properties to keep:
+
+```
+$ geojson-shave roads.geojson -kp id,name,level
+```
+
 Output to a directory other than the current working directory:
+
 ```
 $ geojson-shave roads.geojson -o ../data/output.geojson
 ```

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -418,7 +418,7 @@ class TestProcessFeatures(unittest.TestCase):
                 {
                     "type": "Feature",
                     "geometry": {"type": "Point", "coordinates": [0.123456, 0.123456]},
-                    "properties": {"name": "Feature 1"},
+                    "properties": {"id": 1, "name": "Feature 1"},
                 },
                 {
                     "type": "Feature",
@@ -443,7 +443,7 @@ class TestProcessFeatures(unittest.TestCase):
         self.feature = {
             "type": "Feature",
             "geometry": {"type": "Point", "coordinates": [100.123456, -0.123456]},
-            "properties": {"name": "Example Point"},
+            "properties": {"id": 1, "name": "Example Point"},
         }
 
     def test_feature_collection_truncuation(self):
@@ -457,7 +457,7 @@ class TestProcessFeatures(unittest.TestCase):
                 {
                     "type": "Feature",
                     "geometry": {"type": "Point", "coordinates": [0.123, 0.123]},
-                    "properties": {"name": "Feature 1"},
+                    "properties": {"id": 1, "name": "Feature 1"},
                 },
                 {
                     "type": "Feature",
@@ -480,7 +480,7 @@ class TestProcessFeatures(unittest.TestCase):
 
         self.assertEqual(
             process_features(
-                self.feature_collection, precision, geometry_to_include, False
+                self.feature_collection, precision, geometry_to_include, None
             ),
             expected_return_value,
         )
@@ -494,11 +494,11 @@ class TestProcessFeatures(unittest.TestCase):
         expected_return_value = {
             "type": "Feature",
             "geometry": {"type": "Point", "coordinates": [100.123, -0.123]},
-            "properties": {"name": "Example Point"},
+            "properties": {"id": 1, "name": "Example Point"},
         }
 
         self.assertEqual(
-            process_features(self.feature, precision, geometry_to_include, False),
+            process_features(self.feature, precision, geometry_to_include, None),
             expected_return_value,
         )
 
@@ -506,7 +506,7 @@ class TestProcessFeatures(unittest.TestCase):
         """Test that an exception is raised when an empty
         GeoJSON file is passed."""
         with self.assertRaises(ValueError):
-            process_features(self.blank_feature_collection, 3, ["Point"], False)
+            process_features(self.blank_feature_collection, 3, ["Point"], None)
 
     def test_properties_nullified(self):
         """Test that the properties key returns a null/empty dictionary."""
@@ -540,7 +540,44 @@ class TestProcessFeatures(unittest.TestCase):
 
         self.assertEqual(
             process_features(
-                self.feature_collection, precision, GEOMETRY_OBJECTS, True
+                self.feature_collection, precision, GEOMETRY_OBJECTS, []
+            ),
+            expected_return_value,
+        )
+
+    def test_keep_properties(self):
+        """Test that the properties key returns a null/empty dictionary."""
+        precision = 3
+        expected_return_value = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": [0.123, 0.123]},
+                    "properties": {"id": 1},
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [5.123, 5.123],
+                                [15.123, 5.123],
+                                [15.123, 15.123],
+                                [5.123, 15.123],
+                                [5.123, 5.123],
+                            ]
+                        ],
+                    },
+                    "properties": {},
+                },
+            ],
+        }
+
+        self.assertEqual(
+            process_features(
+                self.feature_collection, precision, GEOMETRY_OBJECTS, ['id', 'nonexist', '']
             ),
             expected_return_value,
         )
@@ -555,7 +592,7 @@ class TestProcessFeatures(unittest.TestCase):
                 {
                     "type": "Feature",
                     "geometry": {"type": "Point", "coordinates": [0.123456, 0.123456]},
-                    "properties": {"name": "Feature 1"},
+                    "properties": {"id": 1, "name": "Feature 1"},
                 },
                 {
                     "type": "Feature",
@@ -578,7 +615,7 @@ class TestProcessFeatures(unittest.TestCase):
 
         self.assertEqual(
             process_features(
-                self.feature_collection, precision, geometry_to_include, False
+                self.feature_collection, precision, geometry_to_include, None
             ),
             expected_return_value,
         )


### PR DESCRIPTION
Great useful tool and awesome logo. I hope removing only some properties instead of all fits into the project scope. I tried reusing the `-p` paramter but it seems impossible to make it optional and also to accept a string parameter. Happy to adjust any wording or variables names, I went back and forth myself how to name things.

```
$ cat points.geojson
{
  "type": "FeatureCollection",
  "features": [
    {
      "properties": { "id": 1, "name": "one" },
      "geometry": { "type": "Point", "coordinates": [1, 1] }
    },
    {
      "properties": { "id": 2, "name": "two" },
      "geometry": { "type": "Point", "coordinates": [2, 2] }
    },
    {
      "properties": { "id": 3, "name": "three" },
      "geometry": { "type": "Point", "coordinates": [3, 3] }
    }
  ]
}

$ jq -c '.features[] | .properties' points.geojson
{"id":1,"name":"one"}
{"id":2,"name":"two"}
{"id":3,"name":"three"}

$ python3 geojson_shave.py -kp id points.geojson
$ jq -c '.features[] | .properties' output.geojson
{"id":1}
{"id":2}
{"id":3}

$ python3 geojson_shave.py -p -kp id points.geojson
$ jq -c '.features[] | .properties' output.geojson
{}
{}
{}

$ python3 geojson_shave.py -kp xyz points.geojson
$ jq -c '.features[] | .properties' output.geojson
{}
{}
{}
```